### PR TITLE
Revert "Revert: Compiler issues"

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ const (
 	defaultTelnetAddr   = "[::1]:40010"
 	defaultBindAddr     = ":40000"
 	defaultListInterval = 300
+	//defaultFallbackServers = [...]string{}
 )
 
 var config Config

--- a/config.go
+++ b/config.go
@@ -15,7 +15,6 @@ const (
 	defaultTelnetAddr   = "[::1]:40010"
 	defaultBindAddr     = ":40000"
 	defaultListInterval = 300
-	//defaultFallbackServers = [...]string{}
 )
 
 var config Config

--- a/process.go
+++ b/process.go
@@ -539,10 +539,10 @@ func (sc *ServerConn) process(pkt mt.Pkt) {
 	case *mt.ToCltKick:
 		sc.Log("<-", "deny access", cmd)
 		
-		if cmd.Reason == mt.Shutdown || cmd.Reason == mt.Crash || cmd.Reason == mt.SrvErr || cmd.Reason == cmd.TooManyClts || cmd.Reason == cmd.UnsupportedVer {
+		if cmd.Reason == mt.Shutdown || cmd.Reason == mt.Crash || cmd.Reason == mt.SrvErr || cmd.Reason == mt.TooManyClts || cmd.Reason == mt.UnsupportedVer {
 			clt.SendChatMsg(cmd.String())
 			for _, srvName := range FallbackServers(sc.name) {
-				if err := clt.Hop(); err != nil {
+				if err := clt.Hop(srvName); err != nil {
 					clt.Log("<-", err)
 					break
 				}

--- a/process.go
+++ b/process.go
@@ -539,10 +539,10 @@ func (sc *ServerConn) process(pkt mt.Pkt) {
 	case *mt.ToCltKick:
 		sc.Log("<-", "deny access", cmd)
 		
-		if cmd.Reason == mt.Shutdown || cmd.Reason == mt.Crash || cmd.Reason == mt.SrvErr || cmd.Reason == mt.TooManyClts || cmd.Reason == mt.UnsupportedVer {
+		if cmd.Reason == mt.Shutdown || cmd.Reason == mt.Crash || cmd.Reason == mt.SrvErr || cmd.Reason == cmd.TooManyClts || cmd.Reason == cmd.UnsupportedVer {
 			clt.SendChatMsg(cmd.String())
 			for _, srvName := range FallbackServers(sc.name) {
-				if err := clt.Hop(srvName); err != nil {
+				if err := clt.Hop(); err != nil {
 					clt.Log("<-", err)
 					break
 				}

--- a/telnet.go
+++ b/telnet.go
@@ -64,7 +64,7 @@ func handleTelnet(conn net.Conn) {
 
 	readString := func(delim byte) (string, error) {
 		s, err := bufio.NewReader(conn).ReadString(delim)
-		i := int(math.Max(float64(len(s)-2), 1))
+		i := int(math.Max(float64(len(s)-1), 1))
 		s = s[:i]
 		return s, err
 	}


### PR DESCRIPTION
This fixes compiler issues:
```
# github.com/HimbeerserverDE/mt-multiserver-proxy
./process.go:542:106: cmd.TooManyClts undefined (type *mt.ToCltKick has no field or method TooManyClts)
./process.go:542:139: cmd.UnsupportedVer undefined (type *mt.ToCltKick has no field or method UnsupportedVer)
./process.go:544:11: srvName declared but not used
./process.go:545:15: not enough arguments in call to clt.Hop
	have ()
	want (string)
```