### PR TITLE
5.5.0 fix & chatcommands in own thread

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -16,7 +16,7 @@ import (
 const (
 	latestSerializeVer = 28
 	latestProtoVer     = 39
-	versionString      = "5.5.0-dev-83a7b48bb"
+	versionString      = "5.4.1-dev-b2596eda3"
 	maxPlayerNameLen   = 20
 	bytesPerMediaBunch = 5000
 )


### PR DESCRIPTION
Fixed compatability with 5.5.0 by updating process.go:
moved packed forwarding code into local func `forward(pkt mt.Pkt)`
changed versionString from "5.5.0-dev-83a7b48bb" to "5.4.1-dev-b2596eda3" to reflect actual version