### PR TITLE
fix variable naming and client compatability issues

### DIFF
--- a/content.go
+++ b/content.go
@@ -118,9 +118,9 @@ func handleContent(cc *contentConn) {
 
 		for cc.state() == csCreated {
 			cc.SendCmd(&mt.ToSrvInit{
-				SerializeVer: latestSerializeVer,
-				MinProtoVer:  latestProtoVer,
-				MaxProtoVer:  latestProtoVer,
+				SerializeVer: serializeVer,
+				MinProtoVer:  protoVer,
+				MaxProtoVer:  protoVer,
 				PlayerName:   cc.userName,
 			})
 			time.Sleep(500 * time.Millisecond)
@@ -158,7 +158,7 @@ func handleContent(cc *contentConn) {
 				cc.auth.method = mt.SRP
 			}
 
-			if cmd.SerializeVer != latestSerializeVer {
+			if cmd.SerializeVer != serializeVer {
 				cc.log("<-", "invalid serializeVer")
 				break
 			}

--- a/list.go
+++ b/list.go
@@ -40,8 +40,8 @@ func announce(action string) error {
 		a["name"] = Conf().List.Name
 		a["description"] = Conf().List.Desc
 		a["version"] = versionString
-		a["proto_min"] = latestProtoVer
-		a["proto_max"] = latestProtoVer
+		a["proto_min"] = protoVer
+		a["proto_max"] = protoVer
 		a["url"] = Conf().List.URL
 		a["creative"] = Conf().List.Creative
 		a["damage"] = Conf().List.Dmg

--- a/process.go
+++ b/process.go
@@ -33,7 +33,7 @@ func (cc *ClientConn) process(pkt mt.Pkt) {
 		}
 
 		cc.setState(csInit)
-		if cmd.SerializeVer <= latestSerializeVer {
+		if cmd.SerializeVer < serializeVer {
 			cc.Log("<-", "invalid serializeVer", cmd.SerializeVer)
 			ack, _ := cc.SendCmd(&mt.ToCltKick{Reason: mt.UnsupportedVer})
 
@@ -46,7 +46,7 @@ func (cc *ClientConn) process(pkt mt.Pkt) {
 			return
 		}
 
-		if cmd.MaxProtoVer <= latestProtoVer {
+		if cmd.MaxProtoVer < protoVer {
 			cc.Log("<-", "invalid protoVer", cmd.MaxProtoVer)
 			ack, _ := cc.SendCmd(&mt.ToCltKick{Reason: mt.UnsupportedVer})
 
@@ -148,8 +148,8 @@ func (cc *ClientConn) process(pkt mt.Pkt) {
 		}
 
 		cc.SendCmd(&mt.ToCltHello{
-			SerializeVer: latestSerializeVer,
-			ProtoVer:     latestProtoVer,
+			SerializeVer: serializeVer,
+			ProtoVer:     protoVer,
 			AuthMethods:  cc.auth.method,
 			Username:     cc.Name(),
 		})
@@ -496,7 +496,7 @@ func (sc *ServerConn) process(pkt mt.Pkt) {
 			sc.auth.method = mt.SRP
 		}
 
-		if cmd.SerializeVer != latestSerializeVer {
+		if cmd.SerializeVer != serializeVer {
 			sc.Log("<-", "invalid serializeVer")
 			return
 		}

--- a/proxy.go
+++ b/proxy.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	latestSerializeVer = 28
-	latestProtoVer     = 39
+	serializeVer       = 28
+	protoVer           = 39
 	versionString      = "5.4.1"
 	maxPlayerNameLen   = 20
 	bytesPerMediaBunch = 5000

--- a/server_conn.go
+++ b/server_conn.go
@@ -91,9 +91,9 @@ func handleSrv(sc *ServerConn) {
 
 		for sc.state() == csCreated && sc.client() != nil {
 			sc.SendCmd(&mt.ToSrvInit{
-				SerializeVer: latestSerializeVer,
-				MinProtoVer:  latestProtoVer,
-				MaxProtoVer:  latestProtoVer,
+				SerializeVer: serializeVer,
+				MinProtoVer:  protoVer,
+				MaxProtoVer:  protoVer,
 				PlayerName:   sc.client().Name(),
 			})
 			time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
This fixes the "Invalid serialisationVer" and "Invalid protoVer" problems with most minetest clients.
This also removes the "latest" from latestSerialisationVer and latestProtoVer, to minimize misunderstanding of these values.