### PR TITLE
Plugin node -> edge

### DIFF
--- a/content.go
+++ b/content.go
@@ -431,6 +431,7 @@ func muxNodeDefs(conns []*contentConn) (nodeDefs []mt.NodeDef, p0Map param0Map, 
 			}
 
 			def.Param0 = param0
+			oldName := def.Name // copy string to use later
 			prepend(cc.mediaPool, &def.Name)
 			prepend(cc.mediaPool, &def.Mesh)
 			for i := range def.Tiles {
@@ -456,6 +457,9 @@ func muxNodeDefs(conns []*contentConn) (nodeDefs []mt.NodeDef, p0Map param0Map, 
 			if param0 >= mt.Unknown && param0 <= mt.Ignore {
 				param0 = mt.Ignore + 1
 			}
+
+			// add nodeid (if reqested)
+			addNodeId(oldName, def.Param0)
 		}
 	}
 

--- a/plugin_map.go
+++ b/plugin_map.go
@@ -36,7 +36,7 @@ func GetNodeId(nodename string) map[mt.Content]bool {
 	if neededNodes[nodename] != nil {
 		return neededNodes[nodename]
 	} else {
-		return map[mt.Content]bool{}
+		return nil
 	}
 }
 

--- a/plugin_map.go
+++ b/plugin_map.go
@@ -64,7 +64,6 @@ func handleBlkData(cc *ClientConn, cmd *mt.ToCltBlkData) bool {
 	defer blkDataHandlersMu.RUnlock()
 
 	handled := false
-
 	for _, handler := range blkDataHandlers {
 		if !handler.UsePos && handler.Handler(cc, cmd) {
 			handled = true

--- a/plugin_map.go
+++ b/plugin_map.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"sync"
+
+	"github.com/anon55555/mt"
+)
+
+type BlkDataHandler struct {
+	Pos     [3]int16 // optional TODO: implement
+	Handler func(*ClientConn, *mt.ToCltBlkData) bool
+}
+
+var blkDataHandlers []BlkDataHandler
+var blkDataHandlersMu sync.RWMutex
+
+var neededNodes = map[string]map[mt.Content]bool{}
+var neededNodesMu sync.RWMutex
+
+// RegisterNeedNode tells server, that nodename is needed
+func RegisterNeedNode(nodename string) {
+	neededNodesMu.Lock()
+	defer neededNodesMu.Unlock()
+
+	if neededNodes[nodename] == nil {
+		neededNodes[nodename] = map[mt.Content]bool{} // default value, empty map
+	}
+}
+
+// GetNodeId gets the nodeid of a
+// If not registerd returns map[mt.Content]bool{}
+func GetNodeId(nodename string) map[mt.Content]bool {
+	neededNodesMu.RLock()
+	defer neededNodesMu.RUnlock()
+
+	if neededNodes[nodename] != nil {
+		return neededNodes[nodename]
+	} else {
+		return map[mt.Content]bool{}
+	}
+}
+
+// addNodeId sets node id, if allready set, ignore
+func addNodeId(nodename string, id mt.Content) {
+	neededNodesMu.Lock()
+	defer neededNodesMu.Unlock()
+
+	if neededNodes[nodename] != nil {
+		neededNodes[nodename][id] = true
+	}
+}
+
+// RegisterBlkDataHandler registers a BlkDataHande
+func RegisterBlkDataHandler(handler BlkDataHandler) {
+	blkDataHandlersMu.Lock()
+	defer blkDataHandlersMu.Unlock()
+
+	blkDataHandlers = append(blkDataHandlers, handler)
+}
+
+func handleBlkData(cc *ClientConn, cmd *mt.ToCltBlkData) bool {
+	blkDataHandlersMu.RLock()
+	defer blkDataHandlersMu.RUnlock()
+
+	handled := false
+
+	for _, handler := range blkDataHandlers {
+		if handler.Handler(cc, cmd) {
+			handled = true
+		}
+	}
+
+	return handled
+}

--- a/plugin_map.go
+++ b/plugin_map.go
@@ -7,34 +7,35 @@ import (
 )
 
 type BlkDataHandler struct {
-	Pos     [3]int16 // optional TODO: implement
+	UsePos  bool     // if set, filters by BlkPos in Pos
+	Pos     [3]int16 // ^ specifies BlkPos when UsePos is set
 	Handler func(*ClientConn, *mt.ToCltBlkData) bool
 }
 
 var blkDataHandlers []BlkDataHandler
 var blkDataHandlersMu sync.RWMutex
 
-var neededNodes = map[string]map[mt.Content]bool{}
-var neededNodesMu sync.RWMutex
+var cacheNodes = map[string]map[mt.Content]bool{}
+var cacheNodesMu sync.RWMutex
 
-// RegisterNeedNode tells server, that nodename is needed
-func RegisterNeedNode(nodename string) {
-	neededNodesMu.Lock()
-	defer neededNodesMu.Unlock()
+// RegisterCacheNode tells server, that nodename is suppost to be cached
+func RegisterCacheNode(nodename string) {
+	cacheNodesMu.Lock()
+	defer cacheNodesMu.Unlock()
 
-	if neededNodes[nodename] == nil {
-		neededNodes[nodename] = map[mt.Content]bool{} // default value, empty map
+	if cacheNodes[nodename] == nil {
+		cacheNodes[nodename] = map[mt.Content]bool{} // default value, empty map
 	}
 }
 
 // GetNodeId gets the nodeid of a
 // If not registerd returns map[mt.Content]bool{}
 func GetNodeId(nodename string) map[mt.Content]bool {
-	neededNodesMu.RLock()
-	defer neededNodesMu.RUnlock()
+	cacheNodesMu.RLock()
+	defer cacheNodesMu.RUnlock()
 
-	if neededNodes[nodename] != nil {
-		return neededNodes[nodename]
+	if cacheNodes[nodename] != nil {
+		return cacheNodes[nodename]
 	} else {
 		return nil
 	}
@@ -42,11 +43,11 @@ func GetNodeId(nodename string) map[mt.Content]bool {
 
 // addNodeId sets node id, if allready set, ignore
 func addNodeId(nodename string, id mt.Content) {
-	neededNodesMu.Lock()
-	defer neededNodesMu.Unlock()
+	cacheNodesMu.Lock()
+	defer cacheNodesMu.Unlock()
 
-	if neededNodes[nodename] != nil {
-		neededNodes[nodename][id] = true
+	if cacheNodes[nodename] != nil {
+		cacheNodes[nodename][id] = true
 	}
 }
 
@@ -65,7 +66,9 @@ func handleBlkData(cc *ClientConn, cmd *mt.ToCltBlkData) bool {
 	handled := false
 
 	for _, handler := range blkDataHandlers {
-		if handler.Handler(cc, cmd) {
+		if !handler.UsePos && handler.Handler(cc, cmd) {
+			handled = true
+		} else if handler.Pos == cmd.Blkpos && handler.Handler(cc, cmd) {
 			handled = true
 		}
 	}

--- a/plugin_node.go
+++ b/plugin_node.go
@@ -1,0 +1,182 @@
+package proxy
+
+import (
+	"sync"
+
+	"github.com/anon55555/mt"
+)
+
+type NodeHandler struct {
+	Node          string
+	nodeIds       map[mt.Content]bool
+	OnDig         func(*ClientConn, *[3]int16) bool
+	OnStopDigging func(*ClientConn, *[3]int16) bool
+	OnDug         func(*ClientConn, *[3]int16) bool
+	OnPlace       func(*ClientConn, *[3]int16) bool
+	OnUse         func(*ClientConn, *[3]int16) bool
+	OnActivate    func(*ClientConn, *[3]int16) bool
+}
+
+var NodeHandlers []*NodeHandler
+var NodeHandlersMu sync.RWMutex
+
+var mapCache     map[[3]int16]*[4096]mt.Content
+var mapCacheMu   sync.RWMutex
+var mapCacheOnce sync.Once
+
+func initMapCache() {
+	mapCacheOnce.Do(func() {
+		mapCache = map[[3]int16]*[4096]mt.Content{}
+	})
+}
+
+func RegisterNodeHandler(handler *NodeHandler) {
+
+	NodeHandlersMu.Lock()
+	defer NodeHandlersMu.Unlock()
+
+	RegisterNeedNode(handler.Node)
+	NodeHandlers = append(NodeHandlers, handler)
+}
+
+func initNodeHandlerNodeIds() {
+	NodeHandlersMu.RLock()
+	defer NodeHandlersMu.RUnlock()
+				
+	for _, h := range NodeHandlers {
+		if h.nodeIds == nil {
+			id := GetNodeId(h.Node)
+
+			if id != nil {
+				h.nodeIds = id
+			}
+		}
+	}
+}
+
+func GetMapCache() map[[3]int16]*[4096]mt.Content {
+	initMapCache()
+	mapCacheMu.RLock()
+	defer mapCacheMu.RUnlock()
+
+	return mapCache
+}
+
+func IsCached(pos [3]int16) bool {
+	initMapCache()
+	mapCacheMu.RLock()
+	defer mapCacheMu.RUnlock()
+
+	blkpos, i := mt.Pos2Blkpos(pos)
+	if mapCache[blkpos] == nil {
+		return false
+	} else {
+		return mapCache[blkpos][i] != 0
+	}
+}
+
+func handleNodeInteraction(cc *ClientConn, pointedNode *mt.PointedNode, cmd *mt.ToSrvInteract) bool {
+	NodeHandlersMu.RLock()
+	defer NodeHandlersMu.RUnlock()
+
+	var handled bool
+
+	for _, handler := range NodeHandlers {
+		var h bool
+	
+		switch cmd.Action {
+		case mt.Dig:
+			if handler.OnDig != nil {
+				h = handler.OnDig(cc, &pointedNode.Under)
+			}
+		case mt.StopDigging:
+			if handler.OnStopDigging != nil {
+				h = handler.OnStopDigging(cc, &pointedNode.Under)
+			}
+		case mt.Dug:
+			if handler.OnDug != nil {
+				h = handler.OnDug(cc, &pointedNode.Under)
+			}
+		case mt.Place:
+			if handler.OnPlace != nil {
+				h = handler.OnPlace(cc, &pointedNode.Under)
+			}
+		case mt.Use:
+			if handler.OnUse != nil {
+				h = handler.OnUse(cc, &pointedNode.Under)
+			}
+		case mt.Activate:
+			if handler.OnActivate != nil {
+				h = handler.OnActivate(cc, &pointedNode.Under)
+			}
+		}
+
+		if h {
+			handled = h
+		}
+	}
+
+	return handled
+}
+
+func initPluginNode() {
+	RegisterBlkDataHandler(BlkDataHandler{
+		Handler: func(cc *ClientConn, cmd *mt.ToCltBlkData) bool {
+			initMapCache()
+
+			initNodeHandlerNodeIds()
+			mapCacheMu.Lock()
+			defer mapCacheMu.Unlock()
+			
+			for i, node := range cmd.Blk.Param0 {
+				// check if node is interesting
+				interesting := false
+				for _, h := range NodeHandlers {
+					if h.nodeIds[node] {
+						interesting = true
+						break
+					}
+				}
+
+				// if it changed
+				// if !interesting && mapCache[cmd.Blkpos][i] != 0 && mapCache[cmd.Blkpos][i] != node {
+				if !interesting {
+					if mapCache[cmd.Blkpos] != nil {
+						if mapCache[cmd.Blkpos][i] != 0 && mapCache[cmd.Blkpos][i] != node {
+							interesting = true
+						}
+					}
+				}
+
+				if interesting {
+					//cc.Log("<>", "interesting mapBlock")
+					if mapCache[cmd.Blkpos] == nil {
+						mapCache[cmd.Blkpos] = &[4096]mt.Content{}
+					}
+					mapCache[cmd.Blkpos][i] = node
+				}
+			}
+
+			return false
+		},
+	})
+
+	RegisterInteractionHandler(InteractionHandler{
+		Type: AnyInteraction,
+		Handler: func(cc *ClientConn, cmd *mt.ToSrvInteract) bool {
+			handled := false
+			
+			if pointedNode, ok := cmd.Pointed.(*mt.PointedNode); ok {
+				if IsCached(pointedNode.Under) {
+					// is a interesting node
+					if handleNodeInteraction(cc, pointedNode, cmd) {
+						handled = true
+					}
+				}
+			}
+		
+			return handled
+		},
+	})
+}
+

--- a/plugin_node.go
+++ b/plugin_node.go
@@ -29,7 +29,6 @@ func initMapCache() {
 }
 
 func RegisterNodeHandler(handler *NodeHandler) {
-
 	NodeHandlersMu.Lock()
 	defer NodeHandlersMu.Unlock()
 
@@ -54,6 +53,7 @@ func initNodeHandlerNodeIds() {
 
 func GetMapCache() map[[3]int16]*[4096]mt.Content {
 	initMapCache()
+
 	mapCacheMu.RLock()
 	defer mapCacheMu.RUnlock()
 
@@ -62,6 +62,7 @@ func GetMapCache() map[[3]int16]*[4096]mt.Content {
 
 func IsCached(pos [3]int16) bool {
 	initMapCache()
+
 	mapCacheMu.RLock()
 	defer mapCacheMu.RUnlock()
 
@@ -76,11 +77,11 @@ func IsCached(pos [3]int16) bool {
 func handleNodeInteraction(cc *ClientConn, pointedNode *mt.PointedNode, cmd *mt.ToSrvInteract) bool {
 	NodeHandlersMu.RLock()
 	defer NodeHandlersMu.RUnlock()
+
 	mapCacheMu.RLock()
 	defer mapCacheMu.RUnlock()
 
 	var handled bool
-
 	for _, handler := range NodeHandlers {
 		// check if nodeId is right
 		pos, i := mt.Pos2Blkpos(pointedNode.Under)
@@ -119,8 +120,8 @@ func initPluginNode() {
 	RegisterBlkDataHandler(BlkDataHandler{
 		Handler: func(cc *ClientConn, cmd *mt.ToCltBlkData) bool {
 			initMapCache()
-
 			initNodeHandlerNodeIds()
+
 			mapCacheMu.Lock()
 			defer mapCacheMu.Unlock()
 
@@ -135,7 +136,6 @@ func initPluginNode() {
 				}
 
 				// if it changed
-				// if !interesting && mapCache[cmd.Blkpos][i] != 0 && mapCache[cmd.Blkpos][i] != node {
 				if !interesting {
 					if mapCache[cmd.Blkpos] != nil {
 						if mapCache[cmd.Blkpos][i] != 0 && mapCache[cmd.Blkpos][i] != node {
@@ -145,7 +145,6 @@ func initPluginNode() {
 				}
 
 				if interesting {
-					//cc.Log("<>", "interesting mapBlock")
 					if mapCache[cmd.Blkpos] == nil {
 						mapCache[cmd.Blkpos] = &[4096]mt.Content{}
 					}

--- a/plugin_node.go
+++ b/plugin_node.go
@@ -12,9 +12,7 @@ type NodeHandler struct {
 	OnDig         func(*ClientConn, *mt.ToSrvInteract) bool
 	OnStopDigging func(*ClientConn, *mt.ToSrvInteract) bool
 	OnDug         func(*ClientConn, *mt.ToSrvInteract) bool
-	OnPlace       func(*ClientConn, *mt.ToSrvInteract) bool
-	OnUse         func(*ClientConn, *mt.ToSrvInteract) bool
-	OnActivate    func(*ClientConn, *mt.ToSrvInteract) bool
+	OnPlace       func(*ClientConn, *mt.ToSrvInteract) bool // TODO IMPLEMENTED
 }
 
 var NodeHandlers []*NodeHandler
@@ -35,7 +33,7 @@ func RegisterNodeHandler(handler *NodeHandler) {
 	NodeHandlersMu.Lock()
 	defer NodeHandlersMu.Unlock()
 
-	RegisterNeedNode(handler.Node)
+	RegisterCacheNode(handler.Node)
 	NodeHandlers = append(NodeHandlers, handler)
 }
 
@@ -105,14 +103,6 @@ func handleNodeInteraction(cc *ClientConn, pointedNode *mt.PointedNode, cmd *mt.
 			case mt.Place:
 				if handler.OnPlace != nil {
 					h = handler.OnPlace(cc, cmd)
-				}
-			case mt.Use:
-				if handler.OnUse != nil {
-					h = handler.OnUse(cc, cmd)
-				}
-			case mt.Activate:
-				if handler.OnActivate != nil {
-					h = handler.OnActivate(cc, cmd)
 				}
 			}
 

--- a/process.go
+++ b/process.go
@@ -807,6 +807,10 @@ func (sc *ServerConn) process(pkt mt.Pkt) {
 			}
 			sc.prependInv(cmd.Blk.NodeMetas[k].Inv)
 		}
+
+		if handleBlkData(sc.client(), cmd) {
+			return
+		}
 	case *mt.ToCltAddNode:
 		sc.globalParam0(&cmd.Node.Param0)
 	case *mt.ToCltAddParticleSpawner:

--- a/run.go
+++ b/run.go
@@ -54,6 +54,9 @@ func runFunc() {
 
 	log.Println("listen", l.Addr())
 
+	// plugin_node.go
+	initPluginNode()
+
 	go func() {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)


### PR DESCRIPTION
This aims to overwrite node interaction for specific nodes, specified by Itemstring.

This is done by...
- implementing a BlkData Handler to handle ToCltBlkData packets using `RegisterBlkDataHandler`
- implementing a itemstring -> nodeid / param0 cache for specific nodes (`RegisterCacheNode`)
- and then by handling interact packages and checking if the node interacted with is registered by some `NodeHandler`.

Some other functions that are a thing:
- `GetMapCache` which returns a copy of the map cache (`map[[3]int16][4096]mt.Content`)
- `IsCached` which returns true, if a node is cached
- `RegisterCachedNode` which tells the ms to save when the specified itemstring is defined
- `GetNodeId` which returns all nodeid's corresponding to a cached itemstring (`map[mt.Content]bool`)

