### PR TITLE
Update to Minetest 5.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ for all versions that were ever supported:
 * Minetest 5.4: [4c90fdd8d212a1c94a7e9ffad587ef610dcc243b](https://github.com/HimbeerserverDE/mt-multiserver-proxy/commit/4c90fdd8d212a1c94a7e9ffad587ef610dcc243b), chat command plugin: [bae3cf2cf232a90203677464d83bbffc50be77b1](https://github.com/HimbeerserverDE/mt-multiserver-chatcommands/commit/bae3cf2cf232a90203677464d83bbffc50be77b1)
 * Minetest 5.5: [dd9e80d6a9a7031c97c64a1979e1e514c092a4cd](https://github.com/HimbeerserverDE/mt-multiserver-proxy/commit/dd9e80d6a9a7031c97c64a1979e1e514c092a4cd), chat command plugin: [fc27ae7c87be94a39bb9ccb15f2ad0b27fcac76c](https://github.com/HimbeerserverDE/mt-multiserver-chatcommands/commit/fc27ae7c87be94a39bb9ccb15f2ad0b27fcac76c)
 * Minetest 5.6: [04705a9129afe3e3f5414af1799667efcc57d3eb](https://github.com/HimbeerserverDE/mt-multiserver-proxy/commit/04705a9129afe3e3f5414af1799667efcc57d3eb), chat command plugin: [4020944da5bce99b878fae4c2d9709f610f4cf6a](https://github.com/HimbeerserverDE/mt-multiserver-chatcommands/commit/4020944da5bce99b878fae4c2d9709f610f4cf6a)
-* Minetest 5.7: latest
+* Minetest 5.7: [629d57a651b46539af3ffed36fb0649b3ea6d346](https://github.com/HimbeerserverDE/mt-multiserver-proxy/commit/629d57a651b46539af3ffed36fb0649b3ea6d346), chat command plugin: [718f8defad54adc04ac81f535b6d59c82a13298e](https://github.com/HimbeerserverDE/mt-multiserver-chatcommands/commit/718f8defad54adc04ac81f535b6d59c82a13298e)
+* Minetest 5.8: latest
 
 The chat command plugin commit hashes are specified for old proxy versions
 that didn't support automatic plugin building and version management yet.

--- a/doc/build_env.md
+++ b/doc/build_env.md
@@ -3,7 +3,7 @@
 ## `go version`
 
 ```
-go version go1.21.4 linux/amd64
+go version go1.21.6 linux/amd64
 ```
 
 ## Build commands

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/HimbeerserverDE/mt-multiserver-proxy
 go 1.21
 
 require (
-	github.com/HimbeerserverDE/mt v0.0.0-20231209140543-691802146fb0
+	github.com/HimbeerserverDE/mt v0.0.0-20240117134628-8d80038fd9e2
 	github.com/HimbeerserverDE/srp v0.0.0
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.18

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/HimbeerserverDE/mt v0.0.0-20231209140543-691802146fb0 h1:2OpNDgV5YikqPeE4Df2RucEMKkzFNCkTOsKO+RHetQ8=
-github.com/HimbeerserverDE/mt v0.0.0-20231209140543-691802146fb0/go.mod h1:RSf7NAuQ5zZC6CTPj5ey/uXPHOdu/oiIvHT8tH3fWK8=
+github.com/HimbeerserverDE/mt v0.0.0-20240117134628-8d80038fd9e2 h1:FQWLAy6qvyZHlsSG8mge72zp15fNZ06gS0SATny/WWc=
+github.com/HimbeerserverDE/mt v0.0.0-20240117134628-8d80038fd9e2/go.mod h1:RSf7NAuQ5zZC6CTPj5ey/uXPHOdu/oiIvHT8tH3fWK8=
 github.com/HimbeerserverDE/srp v0.0.0 h1:Iy2GIF7DJphXXO9NjncLEBO6VsZd8Yhrlxl/qTr09eE=
 github.com/HimbeerserverDE/srp v0.0.0/go.mod h1:pxNH8S2nh4n2DWE0ToX5GnnDr/uEAuaAhJsCpkDLIWw=
 github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=

--- a/proxy.go
+++ b/proxy.go
@@ -17,8 +17,8 @@ import (
 
 const (
 	serializeVer       = 29
-	protoVer           = 42
-	versionString      = "5.7.0"
+	protoVer           = 43
+	versionString      = "5.8.0"
 	maxPlayerNameLen   = 20
 	bytesPerMediaBunch = 5000
 )


### PR DESCRIPTION
This PR updates the version numbers and bumps the `mt` dependency to a version that supports Minetest 5.8. It should not be merged until #144 is.